### PR TITLE
chore: remove some unecessary logic as a first PR

### DIFF
--- a/src/global.zig
+++ b/src/global.zig
@@ -86,10 +86,8 @@ pub const GlobalState = struct {
 
         self.alloc = if (self.gpa) |*value|
             value.allocator()
-        else if (builtin.link_libc)
-            std.heap.c_allocator
         else
-            unreachable;
+            std.heap.c_allocator;
 
         // We first try to parse any action that we may be executing.
         self.action = try cli.action.detectArgs(


### PR DESCRIPTION
Hello,

There are no issues related to that.

As part of my learning journey with Zig, I found the Ghostty project quite appealing as a learning resource.

This is just a small PR that removes what I believe is a useless and unreachable else branch.

Here, gpa refers to the one provided by Zig itself — or, if lib_c is available and you’re building in the appropriate mode, it will use the one from libc. Otherwise, it falls back to Zig’s allocator.

So, in this case, you should always have a valid gpa assignment.

I will now start my journey with the contributor friendly tags

Hopefully will be able to see you on twitch :)

PS: I was looking to run test maybe you can drive me quick how to run the tests I had an issue (I didn't spent too much time looking for it yet)

```
zig build test
test
└─ run test ghostty-test stderr
Requested executable not found. Please verify the command is on
the PATH and try again.
[terminal] (warn): zero-width character with no prior character, ignoring
[screen] (warn): (Screen.adjustCapacity) Failed to add cursor hyperlink back to page, err=error.StringsOutOfMemory
[screen] (warn): (Screen.adjustCapacity) Failed to add cursor style back to page, err=error.OutOfMemory
[page] (warn): page integrity violation y=0 grapheme data but row not marked
[page] (warn): page integrity violation style ref count mismatch id=1 expected=10 actual=9
```